### PR TITLE
Make predicate a conjunction instead of DNF

### DIFF
--- a/proposals/feature-detection/Overview.md
+++ b/proposals/feature-detection/Overview.md
@@ -108,14 +108,8 @@ Format of a conditional section:
 
 | Field     | Type           |
 |-----------|----------------|
-| predicate | `feature_set*` |
+| predicate | `feature*` |
 | contents  | `u8*`          |
-
-Format of a `feature_set`:
-
-| Field    | Type       |
-|----------|------------|
-| features | `feature*` |
 
 Format of a `feature`:
 
@@ -124,12 +118,11 @@ Format of a `feature`:
 | negated | u8             |
 | name    | [`name`][name] |
 
-Predicates are in disjunctive normal form, so they are satisfied if any of their
-component `feature_set`s are satisfied. A `feature_set` is satisfied if all of
-its component `feature`s are satisfied. A `feature` is satisfied if its
-`negated` field is 0 and the host supplies the feature or if its `negated` field
-is 1 and the host does not supply the feature. A `feature` is malformed if its
-`negated` field has any value besides 0 or 1.
+Predicates are conjunctions of possibly-negated features, so they are satisfied
+if all of their component `feature`s are satisfied. A `feature` is satisfied if
+its `negated` field is 0 and the host supplies the feature or if its `negated`
+field is 1 and the host does not supply the feature. A `feature` is malformed if
+its `negated` field has any value besides 0 or 1.
 
 [name]: https://webassembly.github.io/spec/core/binary/values.html#names
 


### PR DESCRIPTION
This is a nice simplification we could make if there is no use case for disjunctions in predicates. In multiversioning schemes like those used in gcc and clang, disjunctions would only ever be useful if the user had the same implementation for multiple feature sets, but then the user might as well have just had one implementation for the intersection of those feature sets, since any feature not in the intersection is clearly not necessary.

The only situation in which conjunctions might be useful is if we want to support some mechanism for the engine to supply custom feature strings that are not related to the actual WebAssembly features supported by the engine. For example, there might be a JS API that allows for supplying extra feature strings to manipulate the behavior of the module. In that case users might want to enable some code if one any of multiple user-specified features were provided.